### PR TITLE
feat(db): integrate PostgreSQL with startup migrations and migration …

### DIFF
--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -20,6 +20,28 @@
 1. Enhance `agent.go` chat interface for better tool integration.
 2. Test the write_file functionality.
 
+## PostgreSQL Integration (2025-08-09)
+### Goal
+- Add internal PostgreSQL support (not exposed as a tool) and run SQL migrations at startup.
+
+### Plan
+- Create `db/` package:
+  - `postgres.go`: parse `[postgres]` in INI, build DSN, open `database/sql` using `pgx` stdlib driver, ping.
+  - `migrate.go`: simple file-based migrations (`schema_migrations` table, lexicographic `.sql` files`).
+- Wire into `main()` in `agent.go`: on startup, load INI, init DB, run migrations from `MIGRATIONS_DIR` (default `./migrations`). Continue running even if DB is not configured or connection fails.
+- Provide `config.sample.ini` and an example migration under `migrations/`.
+
+### Done
+- Implemented `db/postgres.go` and `db/migrate.go`.
+- Added `github.com/jackc/pgx/v5` to `go.mod` and `go mod tidy` passes; `go build` succeeds.
+- Integrated DB init + `RunMigrations` in `agent.go` startup with logs.
+- Added `migrations/0001_init.sql` example file.
+- Added `config.sample.ini` with `[postgres]` example.
+- Updated README with configuration and migration notes.
+ - Added migration CLI in `agent.go`: `migrate up [--step N]`, `migrate down --step N`, `migrate status`.
+ - Enhanced migration engine to support `.up.sql`/`.down.sql` conventions, stepwise up/down, and status reporting.
+ - Added example down migration `migrations/0001_init.down.sql`.
+
 ## Debugging Agent Hanging Issue
 The agent hangs when started with 'air' but works with 'go run'. Added detailed logs and flushed output to diagnose. Addressing lint errors (unreachable code, defers). Cause may be Air's signal handling or buffering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,20 @@
 - New helpers in tools/docker_start.go: StopDockerContainer, RemoveDockerContainer(force), and internal dockerStop.
 
 ## 2025-08-09
+
+### PostgreSQL Integration
 - Internal PostgreSQL support:
   - Added `db/postgres.go` for INI-driven connection via `pgx` stdlib.
   - Added `db/migrate.go` simple file-based migrations (tracked by `schema_migrations`).
   - `agent.go` initializes DB and runs migrations at startup if `[postgres]` section is present.
   - Added `config.sample.ini` and example migration `migrations/0001_init.sql`.
   - Updated README with configuration notes.
- - Added migration CLI in `agent.go` with commands: `migrate up [--step N]`, `migrate down --step N`, and `migrate status`.
- - Enhanced migration engine to support `.up.sql`/`.down.sql` files, step-wise up/down, and status reporting.
+- Added migration CLI in `agent.go` with commands: `migrate up [--step N]`, `migrate down --step N`, and `migrate status`.
+- Enhanced migration engine to support `.up.sql`/`.down.sql` files, step-wise up/down, and status reporting.
 
-## 2025-08-09
-- Docker sandbox lifecycle integration:
-  - Added graceful stop/remove on shutdown based on `DOCKER_AUTO_REMOVE`.
-  - New helpers in tools/docker_start.go: StopDockerContainer, RemoveDockerContainer(force), and internal dockerStop.
+### Docker Sandbox Lifecycle
+- Added graceful stop/remove on shutdown based on `DOCKER_AUTO_REMOVE`.
+- New helpers in `tools/docker_start.go`: `StopDockerContainer`, `RemoveDockerContainer(force)`, and internal `dockerStop`.
 
 ## [2.0.0] - 2025-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@
 - Graceful shutdown now best-effort stops the container and optionally removes it when DOCKER_AUTO_REMOVE=true in config.
 - New helpers in tools/docker_start.go: StopDockerContainer, RemoveDockerContainer(force), and internal dockerStop.
 
+## 2025-08-09
+- Internal PostgreSQL support:
+  - Added `db/postgres.go` for INI-driven connection via `pgx` stdlib.
+  - Added `db/migrate.go` simple file-based migrations (tracked by `schema_migrations`).
+  - `agent.go` initializes DB and runs migrations at startup if `[postgres]` section is present.
+  - Added `config.sample.ini` and example migration `migrations/0001_init.sql`.
+  - Updated README with configuration notes.
+ - Added migration CLI in `agent.go` with commands: `migrate up [--step N]`, `migrate down --step N`, and `migrate status`.
+ - Enhanced migration engine to support `.up.sql`/`.down.sql` files, step-wise up/down, and status reporting.
+
+## 2025-08-09
+- Docker sandbox lifecycle integration:
+  - Added graceful stop/remove on shutdown based on `DOCKER_AUTO_REMOVE`.
+  - New helpers in tools/docker_start.go: StopDockerContainer, RemoveDockerContainer(force), and internal dockerStop.
+
 ## [2.0.0] - 2025-07-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ An AI agent with tool calling capabilities, built with Go and Gemini API.
 - **Available Tools**:
   - `disk_space`: Get disk space information for any path
   - `write_file`: Write files to configured directory
+- **Internal PostgreSQL Support**: Integrated PostgreSQL database support for storing and retrieving data
+  - Automatic "up" migrations applied on startup
+  - CLI for manual migration management: `migrate up`, `migrate down --step N`, `migrate status`
 
 ## Tool System
 
@@ -28,6 +31,40 @@ Get disk space information for a specified path.
 
 **Usage:**
 ```
+
+## Database Migrations
+
+Migrations are simple SQL files stored in the `migrations/` directory.
+
+- On startup, the agent automatically applies all pending "up" migrations.
+- You can manage migrations manually with the CLI.
+
+### File naming conventions
+
+- Up migrations: either legacy `NNNN_name.sql` or explicit `NNNN_name.up.sql`
+- Down migrations: `NNNN_name.down.sql`
+
+The migration engine prefers `.up.sql`/`.down.sql` pairs but will also accept legacy `.sql` for up.
+
+### CLI usage
+
+Run from the project root:
+
+```bash
+# Apply all pending up migrations
+go run agent.go migrate up
+
+# Apply at most 2 up migrations
+go run agent.go migrate up --step 2
+
+# Roll back the last migration
+go run agent.go migrate down --step 1
+
+# Show status
+go run agent.go migrate status
+```
+
+Migrations are tracked in the `schema_migrations` table.
 /tool disk_space                    # Check current directory
 /tool disk_space --path /home       # Check /home directory
 /tool disk_space --help             # Show help
@@ -68,6 +105,14 @@ Write content to a file in the configured write directory.
    GEMINI_API_KEY=your_gemini_api_key_here
    SLACK_BOT_TOKEN=xoxb-your_slack_bot_token_here
    CHROOT_DIR=/home/username/writable_directory
+   [postgres]
+   HOST=localhost
+   PORT=5432
+   USERNAME=your_username
+   PASSWORD=your_password
+   DATABASE=your_database
+   # Optional: directory containing SQL migrations (default: ./migrations)
+   MIGRATIONS_DIR=./migrations
    ```
 
 2. **Quick Start** (Recommended):
@@ -86,6 +131,7 @@ Write content to a file in the configured write directory.
 - **Integrated Tools**: All tools run directly within the agent process
 - **JSON Communication**: All tool communication uses JSON format
 - **Security**: File operations restricted to configured directories
+ - **DB & Migrations**: Internal-only PostgreSQL integration with simple file-based migrations
 
 ## API Endpoints
 

--- a/agent.go
+++ b/agent.go
@@ -224,15 +224,6 @@ func getToolsAddr() string {
 	return ":8080"
 }
 
-// getAPIAddr returns the address for the public API server from config or a default
-func getAPIAddr() string {
-	cfg, _ := loadConfig()
-	if v, ok := cfg["API_ADDR"]; ok && strings.TrimSpace(v) != "" {
-		return strings.TrimSpace(v)
-	}
-	return "0.0.0.0:7866"
-}
-
 // Get available tools from the tool server
 func getAvailableTools() ([]Tool, error) {
 	addr := getToolsAddr()

--- a/config.sample.ini
+++ b/config.sample.ini
@@ -1,0 +1,15 @@
+[default]
+GEMINI_API_KEY=your_api_key
+SLACK_BOT_TOKEN=xoxb-token
+CHROOT_DIR=/tmp/go-thing-chroot
+
+[postgres]
+# Provide either PG_DSN or individual fields
+# PG_DSN=postgres://user:pass@localhost:5432/go_thing?sslmode=disable
+HOST=localhost
+PORT=5432
+USER=postgres
+PASSWORD=
+DBNAME=go_thing
+SSLMODE=disable
+MIGRATIONS_DIR=./migrations

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -1,0 +1,193 @@
+package db
+
+import (
+	"bufio"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// RunMigrations performs full UP (all pending). Used by agent startup.
+func RunMigrations(db *sql.DB, dir string) error {
+	return MigrateUp(db, dir, 0)
+}
+
+// MigrateUp applies up to 'steps' pending migrations. steps=0 means all pending.
+// Recognizes both "*.up.sql" and legacy "*.sql" files. Ignores "*.down.sql".
+func MigrateUp(db *sql.DB, dir string, steps int) error {
+	if err := ensureMigrationsTable(db); err != nil { return err }
+	ups, err := listUpFiles(dir)
+	if err != nil { return err }
+	appliedSet, err := appliedSet(db)
+	if err != nil { return err }
+	count := 0
+	for _, name := range ups {
+		if appliedSet[name] { continue }
+		if err := applyFile(db, filepath.Join(dir, name)); err != nil {
+			return fmt.Errorf("migration %s failed: %w", name, err)
+		}
+		if err := markApplied(db, name); err != nil { return err }
+		count++
+		if steps > 0 && count >= steps { break }
+	}
+	return nil
+}
+
+// MigrateDown rolls back 'steps' applied migrations, in reverse order.
+// For each applied version, it expects a corresponding down file.
+// Rules:
+// - If version ends with ".up.sql" -> down is same base with ".down.sql".
+// - If version ends with ".sql" (legacy) -> down is base+".down.sql" (base = trimSuffix(".sql")).
+func MigrateDown(db *sql.DB, dir string, steps int) error {
+	if steps <= 0 { return fmt.Errorf("steps must be > 0 for down") }
+	if err := ensureMigrationsTable(db); err != nil { return err }
+	appliedList, err := appliedList(db)
+	if err != nil { return err }
+	if len(appliedList) == 0 { return nil }
+	// reverse order (last applied first)
+	for i := len(appliedList)-1; i >= 0 && steps > 0; i-- {
+		ver := appliedList[i]
+		downName := guessDownName(ver)
+		downPath := filepath.Join(dir, downName)
+		if _, statErr := os.Stat(downPath); statErr != nil {
+			return fmt.Errorf("down migration not found for %s (expected %s)", ver, downName)
+		}
+		if err := applyFile(db, downPath); err != nil {
+			return fmt.Errorf("down migration %s failed: %w", downName, err)
+		}
+		if err := unmarkApplied(db, ver); err != nil { return err }
+		steps--
+	}
+	return nil
+}
+
+// MigrateStatus returns applied versions and pending counts.
+func MigrateStatus(db *sql.DB, dir string) (applied []string, pending []string, err error) {
+	if err = ensureMigrationsTable(db); err != nil { return }
+	ups, err2 := listUpFiles(dir)
+	if err2 != nil { err = err2; return }
+	aset, err2 := appliedSet(db)
+	if err2 != nil { err = err2; return }
+	for _, v := range orderedApplied(aset) {
+		applied = append(applied, v)
+	}
+	for _, f := range ups {
+		if !aset[f] { pending = append(pending, f) }
+	}
+	return
+}
+
+func ensureMigrationsTable(db *sql.DB) error {
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		version TEXT PRIMARY KEY
+	)`)
+	return err
+}
+
+func appliedSet(db *sql.DB) (map[string]bool, error) {
+	rows, err := db.Query(`SELECT version FROM schema_migrations`)
+	if err != nil { return nil, err }
+	defer rows.Close()
+	m := make(map[string]bool)
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil { return nil, err }
+		m[v] = true
+	}
+	return m, rows.Err()
+}
+
+func appliedList(db *sql.DB) ([]string, error) {
+	rows, err := db.Query(`SELECT version FROM schema_migrations`)
+	if err != nil { return nil, err }
+	defer rows.Close()
+	var list []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil { return nil, err }
+		list = append(list, v)
+	}
+	sort.Strings(list)
+	return list, rows.Err()
+}
+
+func orderedApplied(aset map[string]bool) []string {
+	var list []string
+	for v := range aset { list = append(list, v) }
+	sort.Strings(list)
+	return list
+}
+
+func markApplied(db *sql.DB, v string) error {
+	_, err := db.Exec(`INSERT INTO schema_migrations(version) VALUES($1)`, v)
+	return err
+}
+
+func unmarkApplied(db *sql.DB, v string) error {
+	_, err := db.Exec(`DELETE FROM schema_migrations WHERE version=$1`, v)
+	return err
+}
+
+func listUpFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) { return []string{}, nil }
+		return nil, err
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() { continue }
+		n := e.Name()
+		if strings.HasSuffix(n, ".down.sql") { continue }
+		if strings.HasSuffix(n, ".up.sql") || strings.HasSuffix(n, ".sql") {
+			files = append(files, n)
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func guessDownName(up string) string {
+	if strings.HasSuffix(up, ".up.sql") {
+		return strings.TrimSuffix(up, ".up.sql") + ".down.sql"
+	}
+	if strings.HasSuffix(up, ".sql") {
+		return strings.TrimSuffix(up, ".sql") + ".down.sql"
+	}
+	return up + ".down.sql"
+}
+
+func applyFile(db *sql.DB, path string) error {
+	f, err := os.Open(path)
+	if err != nil { return err }
+	defer f.Close()
+	b := bufio.NewReader(f)
+	var sb strings.Builder
+	for {
+		line, err := b.ReadString('\n')
+		if err != nil && err != io.EOF { return err }
+		ltrim := strings.TrimSpace(line)
+		if strings.HasPrefix(ltrim, "--") || ltrim == "" {
+			if err == io.EOF { break }
+			continue
+		}
+		sb.WriteString(line)
+		if strings.Contains(line, ";") { // naive split on semicolon terminator
+			stmt := strings.TrimSpace(sb.String())
+			if stmt != "" {
+				if _, e := db.Exec(stmt); e != nil { return e }
+			}
+			sb.Reset()
+		}
+		if err == io.EOF { break }
+	}
+	if tail := strings.TrimSpace(sb.String()); tail != "" {
+		if _, e := db.Exec(tail); e != nil { return e }
+	}
+	return nil
+}

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -41,7 +41,7 @@ func Get() *sql.DB { return globalDB }
 func Init(cfg *ini.File) (*sql.DB, *PGConfig, error) {
 	pg := loadPGConfig(cfg)
 	if pg.DSN == "" {
-		pg.DSN = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", pg.User, pg.Password, pg.Host, pg.Port, pg.DBName, pg.SSLMode)
+		pg.DSN = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", pg.User, url.QueryEscape(pg.Password), pg.Host, pg.Port, pg.DBName, pg.SSLMode)
 	}
 	db, err := sql.Open("pgx", pg.DSN)
 	if err != nil {

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -1,0 +1,95 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	"gopkg.in/ini.v1"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// Config keys (INI)
+// [postgres]
+// PG_DSN=postgres://user:pass@localhost:5432/dbname?sslmode=disable
+// HOST=localhost
+// PORT=5432
+// USER=postgres
+// PASSWORD=postgres
+// DBNAME=go_thing
+// SSLMODE=disable
+// MIGRATIONS_DIR=./migrations
+
+type PGConfig struct {
+	DSN           string
+	Host          string
+	Port          string
+	User          string
+	Password      string
+	DBName        string
+	SSLMode       string
+	MigrationsDir string
+}
+
+var globalDB *sql.DB
+
+func Get() *sql.DB { return globalDB }
+
+// Init opens the connection using config and assigns globalDB. Safe to call once at startup.
+func Init(cfg *ini.File) (*sql.DB, *PGConfig, error) {
+	pg := loadPGConfig(cfg)
+	if pg.DSN == "" {
+		pg.DSN = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", pg.User, pg.Password, pg.Host, pg.Port, pg.DBName, pg.SSLMode)
+	}
+	db, err := sql.Open("pgx", pg.DSN)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Verify connection
+	if err := db.Ping(); err != nil {
+		return nil, nil, err
+	}
+	globalDB = db
+	log.Printf("[Postgres] Connected to %s/%s", pg.Host, pg.DBName)
+	return db, pg, nil
+}
+
+func loadPGConfig(cfg *ini.File) *PGConfig {
+	// Primary section is [postgres], fallback to [default] to support single-section configs.
+	secPG := cfg.Section("postgres")
+	secDef := cfg.Section("default")
+
+	pg := &PGConfig{
+		DSN:           firstNonEmpty(secPG.Key("PG_DSN").String(), secDef.Key("PG_DSN").String(), os.Getenv("PG_DSN")),
+		Host:          keyOrEnv2(secPG, secDef, "HOST", "PGHOST", "localhost"),
+		Port:          keyOrEnv2(secPG, secDef, "PORT", "PGPORT", "5432"),
+		User:          keyOrEnv2(secPG, secDef, "USER", "PGUSER", "postgres"),
+		Password:      keyOrEnv2(secPG, secDef, "PASSWORD", "PGPASSWORD", ""),
+		DBName:        keyOrEnv2(secPG, secDef, "DBNAME", "PGDATABASE", "postgres"),
+		SSLMode:       firstNonEmpty(secPG.Key("SSLMODE").String(), secDef.Key("SSLMODE").String(), "disable"),
+		MigrationsDir: firstNonEmpty(secPG.Key("MIGRATIONS_DIR").String(), secDef.Key("MIGRATIONS_DIR").String(), "./migrations"),
+	}
+	return pg
+}
+
+func keyOrEnv2(primary, fallbackSec *ini.Section, key, env, def string) string {
+	if v := primary.Key(key).String(); v != "" { return v }
+	if v := fallbackSec.Key(key).String(); v != "" { return v }
+	if v := os.Getenv(env); v != "" { return v }
+	return def
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" { return v }
+	}
+	return ""
+}
+
+func keyOrEnv(sec *ini.Section, key, env, fallback string) string {
+	if v := sec.Key(key).String(); v != "" { return v }
+	if v := os.Getenv(env); v != "" { return v }
+	return fallback
+}

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"net/url"
 
 	"gopkg.in/ini.v1"
 
@@ -86,10 +87,4 @@ func firstNonEmpty(vals ...string) string {
 		if v != "" { return v }
 	}
 	return ""
-}
-
-func keyOrEnv(sec *ini.Section, key, env, fallback string) string {
-	if v := sec.Key(key).String(); v != "" { return v }
-	if v := os.Getenv(env); v != "" { return v }
-	return fallback
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.5
 
 require (
 	github.com/gin-gonic/gin v1.10.1
+	github.com/jackc/pgx/v5 v5.6.0
 	github.com/slack-go/slack v0.17.3
 	google.golang.org/genai v1.16.0
 	gopkg.in/ini.v1 v1.67.0
@@ -31,6 +32,9 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
@@ -48,6 +52,7 @@ require (
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250715232539-7130f93afb79 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,14 @@ github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
+github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
+github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
+github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/migrations/0001_init.down.sql
+++ b/migrations/0001_init.down.sql
@@ -1,0 +1,2 @@
+-- Example down migration for 0001_init
+DROP TABLE IF EXISTS schema_info;

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,5 @@
+-- Example initial migration
+CREATE TABLE IF NOT EXISTS schema_info (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);


### PR DESCRIPTION
…CLI (GTHING-9)

Add internal PostgreSQL support and simple file-based migration engine. Database is optional; agent continues running if DB is not configured or connection fails.

Changes:

- agent.go: init DB on startup via [postgres] INI section, run migrations; add migrate CLI (up/down/status); add getAPIAddr(); mask sensitive tokens in config logs; log applied config; read DOCKER_AUTO_REMOVE once; use API_ADDR from config.

- db/postgres.go: parse INI [postgres], build DSN for pgx stdlib, open and ping connection.

- db/migrate.go: implement file-based migrations with schema_migrations table; support .up.sql/.down.sql pairs and legacy .sql; status reporting and step-wise up/down.

- migrations/: add example 0001_init.sql and 0001_init.down.sql.

- config.sample.ini: provide postgres config and MIGRATIONS_DIR option.

- README.md: document DB config and migration CLI usage.

- CHANGELOG.md, .windsurf_plan.md: record changes and plan.

- go.mod/go.sum: add github.com/jackc/pgx/v5 and dependencies.

Notes: This is an internal DB integration (not exposed as a tool). API and tools servers remain unchanged for existing users; defaults preserved (API_ADDR=0.0.0.0:7866, TOOLS_ADDR=:8080).