### PR TITLE
feat(jira): add jira_create_issue tool with convenience params and AD…

### DIFF
--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -235,6 +235,7 @@ Add Jira tools for transitioning issues: list available transitions and perform 
   - `buildJiraCreateIssueBody(params)`: builds the final Jira request body, preserving ADF wrapping, priority/labels handling, and id-vs-name/id-vs-key preferences.
   - Main function now orchestrates parse -> build -> `jiraDo` while preserving existing behavior and error messages.
 - Result: Same functionality with clearer separation of concerns; `go build ./...` passes.
+  - DRY improvements: centralized string-based convenience params parsing via a `stringParams` map+loop; consolidated optional top-level JSON-capable keys (`update`, `properties`, `historyMetadata`, `transition`) handling via a loop over pointers with validation. Expanded label parsing loops to multi-line for readability. Build verified.
 
 ### Developer Experience Improvements
 - The tool server has been converted into a reusable package (`tools`) and is now started inside `agent.go` (as a goroutine) on `:8080`. Running `air` in the project root starts BOTH the agent and the tool server automatically.

--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -754,6 +754,8 @@ Next:
   - Auto-wraps plain-text `description`/`environment` to ADF when needed.
   - Registers executor `executeJiraCreateIssueTool` and integrates with tool registry alongside existing `jira_get_issue`, `jira_edit_issue`, and `jira_delete_issue`.
   - Improves success handling for Jira responses across 2xx statuses.
+  - Robustness: Validate JSON for passthrough params (`update`, `properties`, `historyMetadata`, `transition`); if provided as strings, they must be valid JSON or we return a descriptive error to the user (avoid sending malformed strings to Jira).
+  - Disambiguation: Prefer `projectId` over `projectKey`, and `issuetypeId` over `issuetypeName`, using `if/else if` to avoid setting both fields in the request.
 - Hardened SQL in `utility/context.go` for reading `metadata->'current_context'`:
   - Safely handles non-array or missing `current_context` via CASE expression before checking length.
 

--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -236,6 +236,7 @@ Add Jira tools for transitioning issues: list available transitions and perform 
   - Main function now orchestrates parse -> build -> `jiraDo` while preserving existing behavior and error messages.
 - Result: Same functionality with clearer separation of concerns; `go build ./...` passes.
   - DRY improvements: centralized string-based convenience params parsing via a `stringParams` map+loop; consolidated optional top-level JSON-capable keys (`update`, `properties`, `historyMetadata`, `transition`) handling via a loop over pointers with validation. Expanded label parsing loops to multi-line for readability. Build verified.
+  - Labels: Trim once per element and reuse the result across checks/appends in `buildJiraCreateIssueBody()` to avoid duplicate `strings.TrimSpace` calls for `[]interface{}`, `[]string`, and CSV `string` inputs. Behavior unchanged; readability and micro-efficiency improved. Build verified.
 
 #### Follow-up hardening (2025-08-18)
 - Nil-guard for `fields` parsing in `parseJiraCreateIssueArgs` so a JSON `null` or nil map does not overwrite the initialized map and cause panics during body construction.

--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -746,3 +746,15 @@ Next:
 ### Chat Flow Integration (2025-08-16)
 - The webhook-generated prompt is now injected into the chat flow as a user message, then processed by the AI (Gemini) and stored as an assistant reply.
 - HTTP response to Jira is an empty `200 OK` on success; errors during prompt generation or processing return appropriate `5xx` (or `4xx` for invalid auth/body).
+
+## 2025-08-18 — Jira create issue tool and context SQL hardening
+
+- Added `jira_create_issue` tool in `tools/jira_issue_ops.go`:
+  - Supports full `--fields` JSON or convenience params (project, issuetype, summary, description, labels, priority, assignee, reporter, parent, update/properties/transition, etc.).
+  - Auto-wraps plain-text `description`/`environment` to ADF when needed.
+  - Registers executor `executeJiraCreateIssueTool` and integrates with tool registry alongside existing `jira_get_issue`, `jira_edit_issue`, and `jira_delete_issue`.
+  - Improves success handling for Jira responses across 2xx statuses.
+- Hardened SQL in `utility/context.go` for reading `metadata->'current_context'`:
+  - Safely handles non-array or missing `current_context` via CASE expression before checking length.
+
+Rationale: Enables creating Jira issues directly from the agent and prevents SQL errors when `current_context` is absent or not an array.

--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -16,6 +16,7 @@
 - Added debug logging for exit condition.
 - Confirmed resolution of hanging issue with 'air' after adding terminal check and debug logging.
 - UI: Added Account dropdown in the header and moved "Log out" into it. Files updated: `web/src/App.tsx`, `web/src/app.css`.
+ - Refactor (2025-08-18): DRYed Jira create-issue labels parsing in `tools/jira_issue_ops.go` by introducing a local `addLabel` helper inside `buildJiraCreateIssueBody()` to trim and append non-empty labels from `[]interface{}`, `[]string`, or comma-separated `string`. Behavior preserved.
 
 ## Next Steps
 1. Enhance `agent.go` chat interface for better tool integration.

--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -237,6 +237,11 @@ Add Jira tools for transitioning issues: list available transitions and perform 
 - Result: Same functionality with clearer separation of concerns; `go build ./...` passes.
   - DRY improvements: centralized string-based convenience params parsing via a `stringParams` map+loop; consolidated optional top-level JSON-capable keys (`update`, `properties`, `historyMetadata`, `transition`) handling via a loop over pointers with validation. Expanded label parsing loops to multi-line for readability. Build verified.
 
+#### Follow-up hardening (2025-08-18)
+- Nil-guard for `fields` parsing in `parseJiraCreateIssueArgs` so a JSON `null` or nil map does not overwrite the initialized map and cause panics during body construction.
+- Replaced mutating `handleADFField` helper with pure `processADFValue(raw) (interface{}, bool)` and updated `buildJiraCreateIssueBody` to set `environment` and `description` via the returned value.
+- Benefit: safer map handling and improved reusability/testability of ADF logic. Build verified with `go build ./...`.
+
 ### Developer Experience Improvements
 - The tool server has been converted into a reusable package (`tools`) and is now started inside `agent.go` (as a goroutine) on `:8080`. Running `air` in the project root starts BOTH the agent and the tool server automatically.
 - No need to run a separate tool server process.

--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -195,7 +195,6 @@ Add Jira tools for transitioning issues: list available transitions and perform 
 ### Login timing-attack comment clarification (2025-08-13)
 - File: `agent.go` (`POST /login` handler, non-existent user branch)
 - Change: Expanded the inline comment above `dummyBcryptCompare(p)` to explicitly state it mitigates username-enumeration timing attacks by performing a dummy bcrypt comparison when the user is not found.
-{{ ... }}
 - Reason: Improve maintainability and security clarity for future reviewers; behavior unchanged.
 
 ### Bcrypt timing mitigation hardening (2025-08-13)
@@ -246,8 +245,7 @@ Add Jira tools for transitioning issues: list available transitions and perform 
 ### Developer Experience Improvements
 - The tool server has been converted into a reusable package (`tools`) and is now started inside `agent.go` (as a goroutine) on `:8080`. Running `air` in the project root starts BOTH the agent and the tool server automatically.
 - No need to run a separate tool server process.
-
-{{ ... }}
+ 
 ## Next Steps (Follow-up)
 1. Encourage the agent to call `jira_get_transitions` before `jira_transition_issue` when transition id is unknown (prompt hint or chain-of-thought hinting via tool loop).
 2. Add basic unit tests for the two executors.

--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -228,10 +228,19 @@ Add Jira tools for transitioning issues: list available transitions and perform 
 - Added `jira_transition_issue` tool to perform a transition, supporting body keys: `transition`, `fields`, `update`, `properties`, `historyMetadata` and convenience `transitionId`.
   - Registered both tools in `tools/jira_issue_ops.go` with help text and parameters.
 
+### Refactor: Jira create issue executor (2025-08-18)
+- File: `tools/jira_issue_ops.go`
+- Change: Split `executeJiraCreateIssueTool()` into smaller helpers for maintainability/testability:
+  - `parseJiraCreateIssueArgs(args)`: parses/validates `map[string]interface{}` into a dedicated params struct and validates JSON string passthrough for `update/properties/historyMetadata/transition` and `fields`.
+  - `buildJiraCreateIssueBody(params)`: builds the final Jira request body, preserving ADF wrapping, priority/labels handling, and id-vs-name/id-vs-key preferences.
+  - Main function now orchestrates parse -> build -> `jiraDo` while preserving existing behavior and error messages.
+- Result: Same functionality with clearer separation of concerns; `go build ./...` passes.
+
 ### Developer Experience Improvements
 - The tool server has been converted into a reusable package (`tools`) and is now started inside `agent.go` (as a goroutine) on `:8080`. Running `air` in the project root starts BOTH the agent and the tool server automatically.
 - No need to run a separate tool server process.
 
+{{ ... }}
 ## Next Steps (Follow-up)
 1. Encourage the agent to call `jira_get_transitions` before `jira_transition_issue` when transition id is unknown (prompt hint or chain-of-thought hinting via tool loop).
 2. Add basic unit tests for the two executors.

--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -17,6 +17,8 @@
 - Confirmed resolution of hanging issue with 'air' after adding terminal check and debug logging.
 - UI: Added Account dropdown in the header and moved "Log out" into it. Files updated: `web/src/App.tsx`, `web/src/app.css`.
  - Refactor (2025-08-18): DRYed Jira create-issue labels parsing in `tools/jira_issue_ops.go` by introducing a local `addLabel` helper inside `buildJiraCreateIssueBody()` to trim and append non-empty labels from `[]interface{}`, `[]string`, or comma-separated `string`. Behavior preserved.
+ - Behavior Alignment (2025-08-18): Updated `buildJiraCreateIssueBody()` so user-provided `fields` take precedence over convenience params. Convenience params now apply only when the corresponding key (e.g., `project`, `issuetype`, `summary`, `description`, `labels`, `priority`, `assignee`, `reporter`, `parent`) is absent in `fields`.
+- Documented: jira_create_issue now respects --fields precedence over convenience params.
 
 ## Next Steps
 1. Enhance `agent.go` chat interface for better tool integration.

--- a/tools/jira_issue_ops.go
+++ b/tools/jira_issue_ops.go
@@ -84,8 +84,8 @@ type jiraCreateIssueParams struct {
     IssueTypeID     string
     IssueTypeName   string
     Summary         string
-    Description     interface{} // string or map[string]interface{} (handled via handleADFField at build time)
-    Environment     interface{} // string or map[string]interface{}
+    Description     interface{} // string or map[string]interface{} (handled by processADFValue at build time)
+    Environment     interface{} // string or map[string]interface{} (handled by processADFValue at build time)
     Labels          interface{} // []string | []interface{} | string
     PriorityName    string
     PriorityID      string

--- a/tools/jira_issue_ops.go
+++ b/tools/jira_issue_ops.go
@@ -232,20 +232,25 @@ func buildJiraCreateIssueBody(p *jiraCreateIssueParams) (map[string]interface{},
         switch v := p.Labels.(type) {
         case []interface{}:
             for _, it := range v {
-                if s, ok := it.(string); ok && strings.TrimSpace(s) != "" {
-                    arr = append(arr, strings.TrimSpace(s))
+                if s, ok := it.(string); ok {
+                    trimmed := strings.TrimSpace(s)
+                    if trimmed != "" {
+                        arr = append(arr, trimmed)
+                    }
                 }
             }
         case []string:
             for _, s := range v {
-                if strings.TrimSpace(s) != "" {
-                    arr = append(arr, strings.TrimSpace(s))
+                trimmed := strings.TrimSpace(s)
+                if trimmed != "" {
+                    arr = append(arr, trimmed)
                 }
             }
         case string:
             for _, s := range strings.Split(v, ",") {
-                if strings.TrimSpace(s) != "" {
-                    arr = append(arr, strings.TrimSpace(s))
+                trimmed := strings.TrimSpace(s)
+                if trimmed != "" {
+                    arr = append(arr, trimmed)
                 }
             }
         }

--- a/tools/jira_issue_ops.go
+++ b/tools/jira_issue_ops.go
@@ -39,6 +39,245 @@ func jiraBuildRequest(method, fullURL, email, token string, body []byte) (*http.
 	return req, nil
 }
 
+// ----------------- jira_create_issue -----------------
+// POST /rest/api/3/issue
+func executeJiraCreateIssueTool(args map[string]interface{}) (*ToolResponse, error) {
+    // Build body
+    body := map[string]interface{}{}
+    fields := map[string]interface{}{}
+
+    // Allow full passthrough of fields if provided
+    if raw, ok := args["fields"]; ok {
+        switch v := raw.(type) {
+        case string:
+            if strings.TrimSpace(v) != "" {
+                var obj map[string]interface{}
+                if err := json.Unmarshal([]byte(v), &obj); err == nil {
+                    fields = obj
+                } else {
+                    return &ToolResponse{Success: false, Error: fmt.Sprintf("invalid fields JSON: %v", err)}, nil
+                }
+
+    // environment: accept string and wrap to minimal ADF; or accept object JSON string
+    if raw, ok := args["environment"]; ok {
+        switch v := raw.(type) {
+        case string:
+            s := strings.TrimSpace(v)
+            if s != "" {
+                if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+                    var obj map[string]interface{}
+                    if err := json.Unmarshal([]byte(s), &obj); err == nil {
+                        fields["environment"] = obj
+                    } else {
+                        fields["environment"] = map[string]interface{}{
+                            "type":    "doc",
+                            "version": 1,
+                            "content": []interface{}{
+                                map[string]interface{}{
+                                    "type":    "paragraph",
+                                    "content": []interface{}{map[string]interface{}{"type": "text", "text": s}},
+                                },
+                            },
+                        }
+                    }
+                } else {
+                    fields["environment"] = map[string]interface{}{
+                        "type":    "doc",
+                        "version": 1,
+                        "content": []interface{}{
+                            map[string]interface{}{
+                                "type":    "paragraph",
+                                "content": []interface{}{map[string]interface{}{"type": "text", "text": s}},
+                            },
+                        },
+                    }
+                }
+            }
+        case map[string]interface{}:
+            fields["environment"] = v
+        }
+    }
+            }
+        case map[string]interface{}:
+            fields = v
+        }
+    }
+
+    // Convenience parameters (merged over existing fields without clobbering nested maps unexpectedly)
+    ensureMap := func(m map[string]interface{}, key string) map[string]interface{} {
+        if child, ok := m[key].(map[string]interface{}); ok {
+            return child
+        }
+        child := map[string]interface{}{}
+        m[key] = child
+        return child
+    }
+
+    // project: by key or id
+    if v, ok := args["projectKey"].(string); ok && v != "" {
+        p := ensureMap(fields, "project")
+        p["key"] = v
+    }
+    if v, ok := args["projectId"].(string); ok && v != "" {
+        p := ensureMap(fields, "project")
+        p["id"] = v
+    }
+
+    // issuetype: by id or name
+    if v, ok := args["issuetypeId"].(string); ok && v != "" {
+        it := ensureMap(fields, "issuetype")
+        it["id"] = v
+    }
+    if v, ok := args["issuetypeName"].(string); ok && v != "" {
+        it := ensureMap(fields, "issuetype")
+        it["name"] = v
+    }
+
+    // summary
+    if v, ok := args["summary"].(string); ok && v != "" {
+        fields["summary"] = v
+    }
+
+    // description: accept string and wrap to minimal ADF; or accept object JSON string
+    if raw, ok := args["description"]; ok {
+        switch v := raw.(type) {
+        case string:
+            s := strings.TrimSpace(v)
+            if s != "" {
+                // If looks like JSON object, try to parse and use as-is
+                if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+                    var obj map[string]interface{}
+                    if err := json.Unmarshal([]byte(s), &obj); err == nil {
+                        fields["description"] = obj
+                    } else {
+                        // fallback to ADF wrap
+                        fields["description"] = map[string]interface{}{
+                            "type":    "doc",
+                            "version": 1,
+                            "content": []interface{}{
+                                map[string]interface{}{
+                                    "type":    "paragraph",
+                                    "content": []interface{}{map[string]interface{}{"type": "text", "text": s}},
+                                },
+                            },
+                        }
+                    }
+                } else {
+                    // wrap plain string into ADF
+                    fields["description"] = map[string]interface{}{
+                        "type":    "doc",
+                        "version": 1,
+                        "content": []interface{}{
+                            map[string]interface{}{
+                                "type":    "paragraph",
+                                "content": []interface{}{map[string]interface{}{"type": "text", "text": s}},
+                            },
+                        },
+                    }
+                }
+            }
+        case map[string]interface{}:
+            fields["description"] = v
+        }
+    }
+
+    // labels: accept []interface{}, []string, or comma-separated string
+    if raw, ok := args["labels"]; ok {
+        var arr []string
+        switch v := raw.(type) {
+        case []interface{}:
+            for _, it := range v {
+                if s, ok := it.(string); ok && strings.TrimSpace(s) != "" {
+                    arr = append(arr, strings.TrimSpace(s))
+                }
+            }
+        case []string:
+            for _, s := range v { if strings.TrimSpace(s) != "" { arr = append(arr, strings.TrimSpace(s)) } }
+        case string:
+            for _, s := range strings.Split(v, ",") { if strings.TrimSpace(s) != "" { arr = append(arr, strings.TrimSpace(s)) } }
+        }
+        if len(arr) > 0 { fields["labels"] = arr }
+    }
+
+    // priority by name or id
+    if v, ok := args["priorityName"].(string); ok && v != "" {
+        fields["priority"] = map[string]interface{}{"name": v}
+    }
+    if v, ok := args["priorityId"].(string); ok && v != "" {
+        fields["priority"] = map[string]interface{}{"id": v}
+    }
+
+    // assignee / reporter by accountId
+    if v, ok := args["assigneeAccountId"].(string); ok && v != "" {
+        fields["assignee"] = map[string]interface{}{"accountId": v}
+    }
+    if v, ok := args["reporterAccountId"].(string); ok && v != "" {
+        fields["reporter"] = map[string]interface{}{"accountId": v}
+    }
+
+    // parent (for subtasks): support id or key
+    if v, ok := args["parentId"].(string); ok && v != "" {
+        fields["parent"] = map[string]interface{}{"id": v}
+    } else if v, ok := args["parentKey"].(string); ok && v != "" {
+        fields["parent"] = map[string]interface{}{"key": v}
+    }
+
+    if len(fields) == 0 {
+        return &ToolResponse{Success: false, Error: "fields are required (provide 'fields' or convenience params like projectKey/issuetypeId/summary)"}, nil
+    }
+    body["fields"] = fields
+
+    // Optional: update/properties/historyMetadata/transition passthrough
+    for _, k := range []string{"update", "properties", "historyMetadata", "transition"} {
+        if v, ok := args[k]; ok {
+            // If provided as JSON string, try to parse
+            if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+                var obj interface{}
+                if err := json.Unmarshal([]byte(s), &obj); err == nil {
+                    body[k] = obj
+                    continue
+                }
+            }
+            body[k] = v
+        }
+    }
+
+    status, respBody, _, err := jiraDo("POST", "/rest/api/3/issue", nil, body)
+    if err != nil {
+        return &ToolResponse{Success: false, Error: err.Error()}, nil
+    }
+    if status == http.StatusCreated { // 201
+        var obj map[string]interface{}
+        if err := json.Unmarshal(respBody, &obj); err == nil {
+            return &ToolResponse{Success: true, Data: obj}, nil
+        }
+        return &ToolResponse{Success: true, Data: map[string]interface{}{"message": "issue created"}}, nil
+    }
+    if status < 200 || status >= 300 {
+        // Try to parse Jira error details
+        var eobj map[string]interface{}
+        if len(respBody) > 0 && json.Unmarshal(respBody, &eobj) == nil {
+            var details []string
+            if msgs, ok := eobj["errorMessages"].([]interface{}); ok {
+                for _, m := range msgs { if s, ok := m.(string); ok { details = append(details, s) } }
+            }
+            if errs, ok := eobj["errors"].(map[string]interface{}); ok {
+                for k, v := range errs { details = append(details, fmt.Sprintf("%s: %v", k, v)) }
+            }
+            if len(details) > 0 {
+                return &ToolResponse{Success: false, Error: fmt.Sprintf("jira create issue failed: %d: %s", status, strings.Join(details, "; "))}, nil
+            }
+        }
+        return &ToolResponse{Success: false, Error: fmt.Sprintf("jira create issue failed: %d", status)}, nil
+    }
+    // Other 2xx (rare)
+    var obj interface{}
+    if len(respBody) > 0 && json.Unmarshal(respBody, &obj) == nil {
+        return &ToolResponse{Success: true, Data: obj}, nil
+    }
+    return &ToolResponse{Success: true, Data: map[string]interface{}{"message": "issue created"}}, nil
+}
+
 func jiraDo(method, pathWithParams string, query url.Values, bodyObj interface{}) (int, []byte, http.Header, error) {
 	// Read config
 	cfg, err := ini.Load(os.ExpandEnv(config.ConfigFilePath))
@@ -338,10 +577,10 @@ func executeJiraTransitionIssueTool(args map[string]interface{}) (*ToolResponse,
 }
 
 func init() {
-	tools["jira_get_issue"] = Tool{
-		Name:        "jira_get_issue",
-		Description: "Get Jira issue details by ID or key",
-		Help: `Usage: /tool jira_get_issue --issue <ID-or-KEY> [--fields <csv>] [--fieldsByKeys <bool>] [--expand <s>] [--properties <csv>] [--updateHistory <bool>] [--failFast <bool>]
+    tools["jira_get_issue"] = Tool{
+        Name:        "jira_get_issue",
+        Description: "Get Jira issue details by ID or key",
+        Help: `Usage: /tool jira_get_issue --issue <ID-or-KEY> [--fields <csv>] [--fieldsByKeys <bool>] [--expand <s>] [--properties <csv>] [--updateHistory <bool>] [--failFast <bool>]
 
 Parameters:
   --issue <ID-or-KEY>   Issue ID or key (alias: --issueIdOrKey)
@@ -354,47 +593,85 @@ Parameters:
 
 Examples:
   /tool jira_get_issue --issue PROJ-123`,
-		Parameters: map[string]string{
-			"issue":         "Issue ID or key (alias: issueIdOrKey)",
-			"fields":        "Comma-separated fields",
-			"fieldsByKeys":  "Boolean",
-			"expand":        "Expand parameter",
-			"properties":    "Comma-separated properties",
-			"updateHistory": "Boolean",
-			"failFast":      "Boolean",
-		},
-	}
-	toolExecutors["jira_get_issue"] = executeJiraGetIssueTool
+        Parameters: map[string]string{
+            "issue":         "Issue ID or key (alias: issueIdOrKey)",
+            "fields":        "Comma-separated fields",
+            "fieldsByKeys":  "Boolean",
+            "expand":        "Expand parameter",
+            "properties":    "Comma-separated properties",
+            "updateHistory": "Boolean",
+            "failFast":      "Boolean",
+        },
+    }
+    toolExecutors["jira_get_issue"] = executeJiraGetIssueTool
 
-	tools["jira_edit_issue"] = Tool{
-		Name:        "jira_edit_issue",
-		Description: "Edit Jira issue fields/properties",
-		Help: `Usage: /tool jira_edit_issue --issue <ID-or-KEY> [--notifyUsers <bool>] [--overrideScreenSecurity <bool>] [--overrideEditableFlag <bool>] [--returnIssue <bool>] [--expand <s>] --fields <json> --update <json>
+    // Create issue
+    tools["jira_create_issue"] = Tool{
+        Name:        "jira_create_issue",
+        Description: "Create a Jira issue (supports full fields JSON or convenience params)",
+        Help: `Usage: /tool jira_create_issue [--fields <json>] [--projectKey <key> | --projectId <id>] [--issuetypeId <id> | --issuetypeName <name>] [--summary <text>] [--description <text|json>] [--environment <text|json>] [--labels <csv|json>] [--priorityName <name>] [--priorityId <id>] [--assigneeAccountId <id>] [--reporterAccountId <id>] [--parentId <id> | --parentKey <key>] [--update <json>] [--properties <json>] [--historyMetadata <json>] [--transition <json>]
+
+Notes:
+  - If --fields is provided, it is used as the request fields object.
+  - If --description or --environment is a plain string, it will be wrapped into Atlassian Document Format (ADF) automatically (as required by Jira for textarea fields).
+  - You may pass --transition as a JSON object to move the issue to a different workflow step on creation.
+
+Examples:
+  /tool jira_create_issue --projectKey PROJ --issuetypeName Task --summary "Set up CI" --description "Create CI pipeline"
+  /tool jira_create_issue --fields '{"project":{"key":"PROJ"},"issuetype":{"id":"10001"},"summary":"Do X"}'`,
+        Parameters: map[string]string{
+            "fields":             "JSON object for fields (overrides convenience params)",
+            "projectKey":         "Project key",
+            "projectId":          "Project ID",
+            "issuetypeId":        "Issue type ID",
+            "issuetypeName":      "Issue type name",
+            "summary":            "Summary text",
+            "description":        "ADF JSON object or plain string (auto-wrapped)",
+            "environment":        "ADF JSON object or plain string (auto-wrapped)",
+            "labels":             "CSV string, JSON array, or array",
+            "priorityName":       "Priority name",
+            "priorityId":         "Priority ID",
+            "assigneeAccountId":  "Assignee accountId",
+            "reporterAccountId":  "Reporter accountId",
+            "parentId":           "Parent issue ID (for subtasks)",
+            "parentKey":          "Parent issue key (for subtasks)",
+            "update":             "JSON object",
+            "properties":         "JSON array/object",
+            "historyMetadata":    "JSON object",
+            "transition":         "JSON object for initial transition",
+        },
+    }
+    toolExecutors["jira_create_issue"] = executeJiraCreateIssueTool
+
+    tools["jira_edit_issue"] = Tool{
+        Name:        "jira_edit_issue",
+        Description: "Edit Jira issue fields/properties",
+        Help: `Usage: /tool jira_edit_issue --issue <ID-or-KEY> [--notifyUsers <bool>] [--overrideScreenSecurity <bool>] [--overrideEditableFlag <bool>] [--returnIssue <bool>] [--expand <s>] --fields <json> --update <json>
 
 Body keys (JSON strings are accepted): fields, update, properties, historyMetadata, transition
 
 Examples:
   /tool jira_edit_issue --issue PROJ-123 --fields '{"summary":"New summary"}'`,
-		Parameters: map[string]string{
-			"issue":                 "Issue ID or key (alias: issueIdOrKey)",
-			"notifyUsers":          "Boolean",
-			"overrideScreenSecurity":"Boolean",
-			"overrideEditableFlag": "Boolean",
-			"returnIssue":          "Boolean",
-			"expand":               "Expand parameter",
-			"fields":               "JSON object of fields",
-			"update":               "JSON object of updates",
-			"properties":           "JSON array of properties",
-			"historyMetadata":      "JSON object",
-			"transition":           "JSON object",
-		},
-	}
-	toolExecutors["jira_edit_issue"] = executeJiraEditIssueTool
+        Parameters: map[string]string{
+            "issue":                 "Issue ID or key (alias: issueIdOrKey)",
+            "notifyUsers":          "Boolean",
+            "overrideScreenSecurity":"Boolean",
+            "overrideEditableFlag": "Boolean",
+            "returnIssue":          "Boolean",
+            "expand":               "Expand parameter",
+            "fields":               "JSON object of fields",
+            "update":               "JSON object of updates",
+            "properties":           "JSON array of properties",
+            "historyMetadata":      "JSON object",
+            "transition":           "JSON object",
+        },
+    }
+    toolExecutors["jira_edit_issue"] = executeJiraEditIssueTool
 
-	tools["jira_delete_issue"] = Tool{
-		Name:        "jira_delete_issue",
-		Description: "Delete a Jira issue",
-		Help: `Usage: /tool jira_delete_issue --issue <ID-or-KEY> [--deleteSubtasks <bool|" + "string>]
+    tools["jira_delete_issue"] = Tool{
+        Name:        "jira_delete_issue",
+        Description: "Delete a Jira issue",
+        Help: `Usage: /tool jira_delete_issue --issue <ID-or-KEY> [--deleteSubtasks <bool|" + "string>]
 
 Examples:
   /tool jira_delete_issue --issue PROJ-123 --deleteSubtasks true`,

--- a/tools/jira_issue_ops.go
+++ b/tools/jira_issue_ops.go
@@ -229,29 +229,26 @@ func buildJiraCreateIssueBody(p *jiraCreateIssueParams) (map[string]interface{},
     // labels parsing
     if p.Labels != nil {
         var arr []string
+        addLabel := func(s string) {
+            trimmed := strings.TrimSpace(s)
+            if trimmed != "" {
+                arr = append(arr, trimmed)
+            }
+        }
         switch v := p.Labels.(type) {
         case []interface{}:
             for _, it := range v {
                 if s, ok := it.(string); ok {
-                    trimmed := strings.TrimSpace(s)
-                    if trimmed != "" {
-                        arr = append(arr, trimmed)
-                    }
+                    addLabel(s)
                 }
             }
         case []string:
             for _, s := range v {
-                trimmed := strings.TrimSpace(s)
-                if trimmed != "" {
-                    arr = append(arr, trimmed)
-                }
+                addLabel(s)
             }
         case string:
             for _, s := range strings.Split(v, ",") {
-                trimmed := strings.TrimSpace(s)
-                if trimmed != "" {
-                    arr = append(arr, trimmed)
-                }
+                addLabel(s)
             }
         }
         if len(arr) > 0 { fields["labels"] = arr }

--- a/utility/context.go
+++ b/utility/context.go
@@ -22,8 +22,12 @@ func GetLastContextForThread(threadID int64) ([]string, error) {
          WHERE thread_id=$1
            AND role = 'assistant'
            AND metadata ? 'current_context'
-           AND jsonb_typeof(metadata->'current_context') = 'array'
-           AND jsonb_array_length(metadata->'current_context') > 0
+           AND (
+             CASE WHEN jsonb_typeof(metadata->'current_context') = 'array'
+                  THEN jsonb_array_length(metadata->'current_context')
+                  ELSE 0
+             END
+           ) > 0
          ORDER BY id DESC LIMIT 1`, threadID,
 	).Scan(&metaBytes)
 	if err != nil {


### PR DESCRIPTION
…F auto-wrap

- New tool registered in tools/jira_issue_ops.go with executor and help\n- Supports --fields JSON or params (project, issuetype, summary, description, labels, priority, assignee, reporter, parent, update/properties/transition)\n- Returns success across 2xx and handles JSON body when present

fix(context): harden SQL for current_context type/length checks\n- Use CASE on jsonb_typeof before jsonb_array_length to avoid errors when not an array or missing

docs(plan): update .windsurf_plan.md with summary and rationale (2025-08-18)