### PR TITLE
feat(jira): add issue comments tools and ADF wrapping for update

### DIFF
--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -34,6 +34,22 @@
     - `executeJiraGetProjectTool` (401 handling alongside existing 404 check)
     Reason: clearer, consistent error messages across Jira project tools. Build verified.
 
+### Jira Issue Comments Tools (2025-08-19)
+- Implemented full comment management in `tools/jira_issue_comments.go`:
+  - `jira_get_comments_by_ids` → POST `/rest/api/3/comment/list`
+  - `jira_list_comments` → GET `/rest/api/3/issue/{issueIdOrKey}/comment`
+  - `jira_add_comment` → POST `/rest/api/3/issue/{issueIdOrKey}/comment`
+  - `jira_get_comment` → GET `/rest/api/3/issue/{issueIdOrKey}/comment/{id}`
+  - `jira_update_comment` → PUT `/rest/api/3/issue/{issueIdOrKey}/comment/{id}`
+  - `jira_delete_comment` → DELETE `/rest/api/3/issue/{issueIdOrKey}/comment/{id}`
+- Behavior & robustness:
+  - Accepts `--issueIdOrKey` (alias: `--issue`).
+  - `jira_add_comment` and `jira_update_comment` wrap plain string bodies into minimal Atlassian Document Format (ADF) to avoid 400 errors on Jira Cloud v3.
+  - Parses numeric comment IDs from mixed types (float64/int/string/json.Number) for `jira_get_comments_by_ids`.
+  - Returns parsed JSON objects and propagates Jira error messages where available for better diagnostics.
+- Registered tools in `init()` so they appear in `/api/tools` dynamically.
+- Build verified with `go build ./...`.
+
 ## Next Steps
 1. Enhance `agent.go` chat interface for better tool integration.
 2. Test the write_file functionality.

--- a/tools/jira_issue_comments.go
+++ b/tools/jira_issue_comments.go
@@ -166,7 +166,25 @@ func executeJiraUpdateCommentTool(args map[string]interface{}) (*ToolResponse, e
 	if v, ok := args["expand"].(string); ok && v != "" { q.Set("expand", v) }
 	body := map[string]interface{}{}
 	if v, ok := args["body"].(map[string]interface{}); ok { body["body"] = v }
-	if v, ok := args["body"].(string); ok && v != "" { body["body"] = v }
+	if v, ok := args["body"].(string); ok && v != "" {
+		// Jira Cloud v3 requires Atlassian Document Format (ADF). If a plain string is supplied,
+		// wrap it into a minimal ADF document to avoid 400 errors, same as add comment.
+		body["body"] = map[string]interface{}{
+			"type":    "doc",
+			"version": 1,
+			"content": []interface{}{
+				map[string]interface{}{
+					"type": "paragraph",
+					"content": []interface{}{
+						map[string]interface{}{
+							"type": "text",
+							"text": v,
+						},
+					},
+				},
+			},
+		}
+	}
 	if v, ok := args["visibility"].(map[string]interface{}); ok { body["visibility"] = v }
 	if v, ok := args["properties"].([]interface{}); ok { body["properties"] = v }
 	if _, exists := body["body"]; !exists {


### PR DESCRIPTION
- Implement tools in tools/jira_issue_comments.go:
  - jira_get_comments_by_ids (POST /rest/api/3/comment/list)
  - jira_list_comments (GET /rest/api/3/issue/{issueIdOrKey}/comment)
  - jira_add_comment (POST /rest/api/3/issue/{issueIdOrKey}/comment)
  - jira_get_comment (GET /rest/api/3/issue/{issueIdOrKey}/comment/{id})
  - jira_update_comment (PUT /rest/api/3/issue/{issueIdOrKey}/comment/{id})
  - jira_delete_comment (DELETE /rest/api/3/issue/{issueIdOrKey}/comment/{id})
- Wrap plain string bodies into minimal ADF for add and update to avoid Jira v3 400s
- Register executors via init() so tools are auto-discovered
- Update .windsurf_plan.md documenting behavior and usage

Relates-to: GTHING-28