### PR TITLE
feat(settings): Persona Settings for System Prompts

### DIFF
--- a/migrations/0008_system_prompts.down.sql
+++ b/migrations/0008_system_prompts.down.sql
@@ -1,0 +1,8 @@
+-- 0008_system_prompts.down.sql
+-- Drop per-user System Prompts storage
+
+DROP TRIGGER IF EXISTS set_timestamp_on_system_prompts ON system_prompts;
+DROP FUNCTION IF EXISTS trg_set_timestamp();
+DROP INDEX IF EXISTS ix_system_prompts_user_active;
+DROP INDEX IF EXISTS ux_system_prompts_one_default_per_user;
+DROP TABLE IF EXISTS system_prompts;

--- a/migrations/0008_system_prompts.up.sql
+++ b/migrations/0008_system_prompts.up.sql
@@ -1,0 +1,39 @@
+-- 0008_system_prompts.up.sql
+-- Create per-user System Prompts storage
+
+CREATE TABLE IF NOT EXISTS system_prompts (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    content TEXT NOT NULL,
+    preferred_llms TEXT[] NOT NULL DEFAULT '{}',
+    active BOOLEAN NOT NULL DEFAULT FALSE,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT system_prompts_default_requires_active CHECK (NOT is_default OR active)
+);
+
+-- Ensure only one default per user (at most)
+CREATE UNIQUE INDEX IF NOT EXISTS ux_system_prompts_one_default_per_user
+    ON system_prompts(user_id)
+    WHERE is_default = TRUE;
+
+-- Index for quick lookups by user and activity
+CREATE INDEX IF NOT EXISTS ix_system_prompts_user_active
+    ON system_prompts(user_id, active);
+
+-- Trigger to bump updated_at on row updates
+CREATE OR REPLACE FUNCTION trg_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_timestamp_on_system_prompts ON system_prompts;
+CREATE TRIGGER set_timestamp_on_system_prompts
+BEFORE UPDATE ON system_prompts
+FOR EACH ROW
+EXECUTE PROCEDURE trg_set_timestamp();

--- a/routes/api_settings_routes.go
+++ b/routes/api_settings_routes.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
+
+	"go-thing/db"
+	"go-thing/utility"
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/bcrypt"
-	"go-thing/db"
-	"go-thing/utility"
 )
 
 // RegisterAPISettingsRoutes registers authenticated settings-related endpoints under the provided auth group.
@@ -249,6 +251,302 @@ func RegisterAPISettingsRoutes(auth *gin.RouterGroup) {
 		if _, err := dbc.Exec(upd, string(b), uid); err != nil {
 			log.Printf("[DockerSettings] update err: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	// System Prompts CRUD
+	// List prompts for current user
+	auth.GET("/api/settings/prompts", func(c *gin.Context) {
+		v, ok := c.Get("userID")
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "user ID not found in context"})
+			return
+		}
+		uid, ok := v.(int64)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+			return
+		}
+		dbc := db.Get()
+		if dbc == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "database not initialized"})
+			return
+		}
+		rows, err := dbc.Query(`SELECT id, name, content, COALESCE(to_json(preferred_llms)::text,'[]') AS preferred_json, active, is_default, created_at, updated_at FROM system_prompts WHERE user_id=$1 ORDER BY updated_at DESC`, uid)
+		if err != nil {
+			log.Printf("[Prompts] list err: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed"})
+			return
+		}
+		defer rows.Close()
+		type Prompt struct {
+			ID            int64    `json:"id"`
+			Name          string   `json:"name"`
+			Content       string   `json:"content"`
+			PreferredLLMs []string `json:"preferred_llms"`
+			Active        bool     `json:"active"`
+			IsDefault     bool     `json:"default"`
+			CreatedAt     string   `json:"created_at"`
+			UpdatedAt     string   `json:"updated_at"`
+		}
+		prompts := []Prompt{}
+		for rows.Next() {
+			var p Prompt
+			var prefJSON string
+			if err := rows.Scan(&p.ID, &p.Name, &p.Content, &prefJSON, &p.Active, &p.IsDefault, &p.CreatedAt, &p.UpdatedAt); err != nil {
+				log.Printf("[Prompts] scan err: %v", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed"})
+				return
+			}
+			var arr []string
+			_ = json.Unmarshal([]byte(prefJSON), &arr)
+			p.PreferredLLMs = arr
+			prompts = append(prompts, p)
+		}
+		c.JSON(http.StatusOK, gin.H{"prompts": prompts})
+	})
+
+	// Create prompt
+	auth.POST("/api/settings/prompts", func(c *gin.Context) {
+		if !utility.ValidateCSRF(c) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "csrf invalid"})
+			return
+		}
+		v, ok := c.Get("userID")
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "user ID not found in context"})
+			return
+		}
+		uid, ok := v.(int64)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+			return
+		}
+		var req struct {
+			Name          string   `json:"name"`
+			Content       string   `json:"content"`
+			PreferredLLMs []string `json:"preferred_llms"`
+			Active        *bool    `json:"active"`
+			IsDefault     *bool    `json:"default"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+			return
+		}
+		name := strings.TrimSpace(req.Name)
+		content := req.Content
+		if name == "" || strings.TrimSpace(content) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "name and content are required"})
+			return
+		}
+		active := false
+		if req.Active != nil {
+			active = *req.Active
+		}
+		isDefault := false
+		if req.IsDefault != nil {
+			isDefault = *req.IsDefault
+		}
+		if isDefault {
+			active = true
+		}
+		dbc := db.Get()
+		if dbc == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "database not initialized"})
+			return
+		}
+		tx, err := dbc.Begin()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed"})
+			return
+		}
+		defer func() { _ = tx.Rollback() }()
+		if isDefault {
+			if _, err := tx.Exec(`UPDATE system_prompts SET is_default=FALSE WHERE user_id=$1 AND is_default=TRUE`, uid); err != nil {
+				log.Printf("[Prompts] clear defaults err: %v", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed"})
+				return
+			}
+		}
+		var id int64
+		err = tx.QueryRow(
+			`INSERT INTO system_prompts(user_id, name, content, preferred_llms, active, is_default) VALUES($1,$2,$3,$4,$5,$6) RETURNING id`,
+			uid, name, content, req.PreferredLLMs, active, isDefault,
+		).Scan(&id)
+		if err != nil {
+			log.Printf("[Prompts] insert err: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to insert"})
+			return
+		}
+		if err := tx.Commit(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"id": id})
+	})
+
+	// Update prompt
+	auth.PUT("/api/settings/prompts/:id", func(c *gin.Context) {
+		if !utility.ValidateCSRF(c) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "csrf invalid"})
+			return
+		}
+		v, ok := c.Get("userID")
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "user ID not found in context"})
+			return
+		}
+		uid, ok := v.(int64)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+			return
+		}
+		pidStr := c.Param("id")
+		pid, err := strconv.ParseInt(pidStr, 10, 64)
+		if err != nil || pid <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+			return
+		}
+		var req struct {
+			Name          *string  `json:"name"`
+			Content       *string  `json:"content"`
+			PreferredLLMs []string `json:"preferred_llms"`
+			Active        *bool    `json:"active"`
+			IsDefault     *bool    `json:"default"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+			return
+		}
+		dbc := db.Get()
+		if dbc == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "database not initialized"})
+			return
+		}
+		tx, err := dbc.Begin()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed"})
+			return
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		// Load current values to enforce rules
+		var curIsDefault bool
+		if err := tx.QueryRow(`SELECT is_default FROM system_prompts WHERE id=$1 AND user_id=$2`, pid, uid).Scan(&curIsDefault); err != nil {
+			if err == sql.ErrNoRows {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed"})
+			return
+		}
+
+		// Enforce: default cannot be disabled
+		if req.Active != nil && !*req.Active {
+			// If currently default or becoming default, reject
+			nextIsDefault := curIsDefault
+			if req.IsDefault != nil {
+				nextIsDefault = *req.IsDefault
+			}
+			if nextIsDefault {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "default prompt cannot be disabled"})
+				return
+			}
+		}
+
+		// If setting default true, clear others
+		if req.IsDefault != nil && *req.IsDefault {
+			if _, err := tx.Exec(`UPDATE system_prompts SET is_default=FALSE WHERE user_id=$1 AND is_default=TRUE AND id<>$2`, uid, pid); err != nil {
+				log.Printf("[Prompts] clear defaults err: %v", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed"})
+				return
+			}
+		}
+
+		// Build dynamic update
+		setParts := []string{}
+		args := []interface{}{}
+		idx := 1
+		if req.Name != nil {
+			setParts = append(setParts, "name=$"+strconv.Itoa(idx))
+			args = append(args, strings.TrimSpace(*req.Name))
+			idx++
+		}
+		if req.Content != nil {
+			setParts = append(setParts, "content=$"+strconv.Itoa(idx))
+			args = append(args, *req.Content)
+			idx++
+		}
+		if req.Active != nil {
+			setParts = append(setParts, "active=$"+strconv.Itoa(idx))
+			args = append(args, *req.Active)
+			idx++
+		}
+		if req.IsDefault != nil {
+			setParts = append(setParts, "is_default=$"+strconv.Itoa(idx))
+			// If making default, also ensure active=true implicitly
+			args = append(args, *req.IsDefault)
+			idx++
+			if *req.IsDefault {
+				setParts = append(setParts, "active=TRUE")
+			}
+		}
+		if req.PreferredLLMs != nil {
+			setParts = append(setParts, "preferred_llms=$"+strconv.Itoa(idx))
+			args = append(args, req.PreferredLLMs)
+			idx++
+		}
+		if len(setParts) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "no fields to update"})
+			return
+		}
+		// updated_at is bumped by trigger
+		q := "UPDATE system_prompts SET " + strings.Join(setParts, ", ") + " WHERE id=$" + strconv.Itoa(idx) + " AND user_id=$" + strconv.Itoa(idx+1)
+		args = append(args, pid, uid)
+		if _, err := tx.Exec(q, args...); err != nil {
+			log.Printf("[Prompts] update err: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update"})
+			return
+		}
+		if err := tx.Commit(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	// Delete prompt
+	auth.DELETE("/api/settings/prompts/:id", func(c *gin.Context) {
+		if !utility.ValidateCSRF(c) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "csrf invalid"})
+			return
+		}
+		v, ok := c.Get("userID")
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "user ID not found in context"})
+			return
+		}
+		uid, ok := v.(int64)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+			return
+		}
+		pidStr := c.Param("id")
+		pid, err := strconv.ParseInt(pidStr, 10, 64)
+		if err != nil || pid <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+			return
+		}
+		dbc := db.Get()
+		if dbc == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "database not initialized"})
+			return
+		}
+		if _, err := dbc.Exec(`DELETE FROM system_prompts WHERE id=$1 AND user_id=$2`, pid, uid); err != nil {
+			log.Printf("[Prompts] delete err: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete"})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"ok": true})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,20 +27,21 @@ export default function App() {
   const accountMenuRef = React.useRef<HTMLDivElement | null>(null);
   // Routing now uses pathname for page and path segment for settings tab
   const getRoute = () => window.location.pathname || "/";
-  const getTabFromPath = (): "profile" | "password" | "docker" => {
+  const getTabFromPath = (): "profile" | "password" | "docker" | "personal" => {
     const p = (window.location.pathname || "/").toLowerCase();
     if (!p.startsWith("/account/settings")) return "profile";
     const parts = p.split("/").filter(Boolean); // e.g., ["account","settings","docker"]
     const maybe = parts[2] || "";
     if (maybe === "password") return "password";
     if (maybe === "docker") return "docker";
+    if (maybe === "personal") return "personal";
     return "profile";
   };
 
   const [route, setRoute] = React.useState<string>(() => getRoute());
   // Settings tab state lifted to App for a fixed toolbar under header
   const [settingsTab, setSettingsTab] = React.useState<
-    "profile" | "password" | "docker"
+    "profile" | "password" | "docker" | "personal"
   >(() => getTabFromPath());
 
   React.useEffect(() => {
@@ -334,6 +335,25 @@ export default function App() {
           >
             Docker Settings
           </button>
+          <button
+            role="tab"
+            aria-selected={settingsTab === "personal"}
+            className={settingsTab === "personal" ? "link active" : "link"}
+            onClick={() => {
+              setSettingsTab("personal");
+              navigate("/account/settings/personal");
+            }}
+            style={{
+              color: settingsTab === "personal" ? "#FFFFFF" : "#D1D5DB",
+              borderBottom:
+                settingsTab === "personal"
+                  ? "2px solid #60A5FA"
+                  : "2px solid transparent",
+              paddingBottom: 4,
+            }}
+          >
+            Persona Settings
+          </button>
         </div>
       )}
       {route.startsWith("/account/settings") ? (
@@ -425,8 +445,8 @@ function safeMarked(s: string): string {
 
 type SettingsProps = {
   me: User | null;
-  tab: "profile" | "password" | "docker";
-  onChangeTab: (t: "profile" | "password" | "docker") => void;
+  tab: "profile" | "password" | "docker" | "personal";
+  onChangeTab: (t: "profile" | "password" | "docker" | "personal") => void;
   onNameUpdated: (newName: string) => void;
 };
 
@@ -470,6 +490,190 @@ function SettingsPage({ me, tab, onChangeTab, onNameUpdated }: SettingsProps) {
   const [downloadingWhich, setDownloadingWhich] = React.useState<
     "public" | "private" | null
   >(null);
+
+  // Personal Settings: System Prompts state
+  type Prompt = {
+    id: number;
+    name: string;
+    content: string;
+    preferred_llms: string[];
+    active: boolean;
+    default: boolean;
+    created_at?: string;
+    updated_at?: string;
+  };
+  const [prompts, setPrompts] = React.useState<Prompt[]>([]);
+  const [selectedPromptId, setSelectedPromptId] = React.useState<number | null>(
+    null
+  );
+  const [pName, setPName] = React.useState("");
+  const [pContent, setPContent] = React.useState("");
+  const [pLLMs, setPLLMs] = React.useState(""); // comma-separated
+  const [pActive, setPActive] = React.useState(false);
+  const [pDefault, setPDefault] = React.useState(false);
+  const [pLoading, setPLoading] = React.useState(false);
+  const [pSaving, setPSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    if (tab !== "personal") return;
+    let aborted = false;
+    setPLoading(true);
+    (async () => {
+      try {
+        const res = await fetch("/api/settings/prompts");
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        const list: Prompt[] = Array.isArray(data?.prompts) ? data.prompts : [];
+        if (!aborted) {
+          setPrompts(list);
+          if (list.length > 0) {
+            const first = list[0];
+            setSelectedPromptId(first.id);
+            setPName(first.name || "");
+            setPContent(first.content || "");
+            setPLLMs((first.preferred_llms || []).join(", "));
+            setPActive(!!first.active);
+            setPDefault(!!first.default);
+          } else {
+            setSelectedPromptId(null);
+            setPName("");
+            setPContent("");
+            setPLLMs("");
+            setPActive(false);
+            setPDefault(false);
+          }
+        }
+      } catch (e: any) {
+        if (!aborted)
+          setMessage(`Failed to load System Prompts: ${e?.message ?? e}`);
+      } finally {
+        if (!aborted) setPLoading(false);
+      }
+    })();
+    return () => {
+      aborted = true;
+    };
+  }, [tab]);
+
+  function onSelectPrompt(p: Prompt) {
+    setSelectedPromptId(p.id);
+    setPName(p.name || "");
+    setPContent(p.content || "");
+    setPLLMs((p.preferred_llms || []).join(", "));
+    setPActive(!!p.active);
+    setPDefault(!!p.default);
+    setMessage(null);
+  }
+
+  function newPrompt() {
+    setSelectedPromptId(null);
+    setPName("");
+    setPContent("");
+    setPLLMs("");
+    setPActive(false);
+    setPDefault(false);
+    setMessage(null);
+  }
+
+  async function savePrompt() {
+    try {
+      setPSaving(true);
+      setMessage(null);
+      const name = pName.trim();
+      if (!name || !pContent.trim()) {
+        setMessage("Name and content are required");
+        return;
+      }
+      const preferred_llms = pLLMs
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const token = await fetchCSRFToken();
+      if (selectedPromptId == null) {
+        const res = await fetch("/api/settings/prompts", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": token,
+          },
+          body: JSON.stringify({
+            name,
+            content: pContent,
+            preferred_llms,
+            active: !!pActive,
+            default: !!pDefault,
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const created = await res.json();
+        // reload list
+        const listRes = await fetch("/api/settings/prompts");
+        const data = await listRes.json();
+        const list: Prompt[] = Array.isArray(data?.prompts) ? data.prompts : [];
+        setPrompts(list);
+        if (created?.id) {
+          const found = list.find((x) => x.id === created.id);
+          if (found) onSelectPrompt(found);
+        }
+        setMessage("Prompt created");
+      } else {
+        const res = await fetch(`/api/settings/prompts/${selectedPromptId}`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": token,
+          },
+          body: JSON.stringify({
+            name,
+            content: pContent,
+            preferred_llms,
+            active: !!pActive,
+            default: !!pDefault,
+          }),
+        });
+        const txt = await res.text();
+        if (!res.ok) throw new Error(txt || `HTTP ${res.status}`);
+        // reload list to reflect changes
+        const listRes = await fetch("/api/settings/prompts");
+        const data = await listRes.json();
+        const list: Prompt[] = Array.isArray(data?.prompts) ? data.prompts : [];
+        setPrompts(list);
+        const found = list.find((x) => x.id === selectedPromptId);
+        if (found) onSelectPrompt(found);
+        setMessage("Prompt saved");
+      }
+    } catch (e: any) {
+      setMessage(typeof e?.message === "string" ? e.message : "Failed to save");
+    } finally {
+      setPSaving(false);
+    }
+  }
+
+  async function deletePrompt() {
+    if (selectedPromptId == null) return;
+    try {
+      setMessage(null);
+      const token = await fetchCSRFToken();
+      const res = await fetch(`/api/settings/prompts/${selectedPromptId}`, {
+        method: "DELETE",
+        headers: { "X-CSRF-Token": token },
+      });
+      const txt = await res.text();
+      if (!res.ok) throw new Error(txt || `HTTP ${res.status}`);
+      // reload
+      const listRes = await fetch("/api/settings/prompts");
+      const data = await listRes.json();
+      const list: Prompt[] = Array.isArray(data?.prompts) ? data.prompts : [];
+      setPrompts(list);
+      if (list.length) onSelectPrompt(list[0]);
+      else newPrompt();
+      setMessage("Prompt deleted");
+    } catch (e: any) {
+      setMessage(
+        typeof e?.message === "string" ? e.message : "Failed to delete"
+      );
+    }
+  }
 
   React.useEffect(() => {
     let aborted = false;
@@ -760,7 +964,7 @@ function SettingsPage({ me, tab, onChangeTab, onNameUpdated }: SettingsProps) {
       aria-atomic="false"
       style={{
         padding: "1rem",
-        paddingBottom: tab === "docker" ? "8rem" : "1rem",
+        paddingBottom: tab === "docker" || tab === "personal" ? "8rem" : "1rem",
       }}
     >
       <h1 style={{ margin: "0 0 1rem 0" }}>User Settings</h1>
@@ -768,7 +972,7 @@ function SettingsPage({ me, tab, onChangeTab, onNameUpdated }: SettingsProps) {
         <div>Loading…</div>
       ) : (
         <>
-          {message && tab !== "docker" && (
+          {message && tab !== "docker" && tab !== "personal" && (
             <div
               className="system-msg"
               role="status"
@@ -811,6 +1015,193 @@ function SettingsPage({ me, tab, onChangeTab, onNameUpdated }: SettingsProps) {
                   </button>
                 </div>
               </form>
+            </section>
+          )}
+
+          {tab === "personal" && (
+            <section
+              style={{
+                display: "grid",
+                gridTemplateColumns: "280px 1fr",
+                gap: "1rem",
+              }}
+            >
+              <div>
+                <h2 style={{ margin: "0 0 0.5rem 0" }}>System Prompts</h2>
+                {pLoading ? (
+                  <div>Loading…</div>
+                ) : (
+                  <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                    {prompts.map((p) => (
+                      <li key={p.id} style={{ marginBottom: 6 }}>
+                        <button
+                          className={
+                            selectedPromptId === p.id ? "link active" : "link"
+                          }
+                          onClick={() => onSelectPrompt(p)}
+                          style={{ width: "100%", textAlign: "left" }}
+                        >
+                          {p.name}
+                          {p.default
+                            ? "  • default"
+                            : p.active
+                            ? "  • active"
+                            : ""}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {/* New Prompt moved to bottom action bar */}
+              </div>
+              <div>
+                <h2 style={{ margin: "0 0 0.5rem 0" }}>
+                  {selectedPromptId == null ? "New Prompt" : "Edit Prompt"}
+                </h2>
+                <div
+                  className="row"
+                  style={{ gap: "0.5rem", alignItems: "baseline" }}
+                >
+                  <label style={{ minWidth: 120 }}>Name</label>
+                  <input
+                    type="text"
+                    value={pName}
+                    onChange={(e) => setPName(e.target.value)}
+                  />
+                </div>
+                <div
+                  className="row"
+                  style={{
+                    gap: "0.5rem",
+                    alignItems: "flex-start",
+                    marginTop: "0.5rem",
+                  }}
+                >
+                  <label style={{ minWidth: 120, paddingTop: 6 }}>
+                    System Prompt (Markdown)
+                  </label>
+                  <textarea
+                    style={{
+                      fontFamily:
+                        'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                      width: "100%",
+                      minHeight: 220,
+                    }}
+                    placeholder={
+                      "# Instructions\nYou are a helpful assistant..."
+                    }
+                    value={pContent}
+                    onChange={(e) => setPContent(e.target.value)}
+                  />
+                </div>
+                <div
+                  className="row"
+                  style={{
+                    gap: "0.5rem",
+                    alignItems: "baseline",
+                    marginTop: "0.5rem",
+                  }}
+                >
+                  <label style={{ minWidth: 120 }}>Preferred LLMs</label>
+                  <input
+                    type="text"
+                    placeholder="comma-separated (e.g., gemini-1.5-pro, gpt-4o, claude-3.5-sonnet)"
+                    value={pLLMs}
+                    onChange={(e) => setPLLMs(e.target.value)}
+                  />
+                </div>
+                <div
+                  className="row"
+                  style={{
+                    gap: "0.5rem",
+                    alignItems: "center",
+                    marginTop: "0.5rem",
+                  }}
+                >
+                  <label style={{ minWidth: 120 }}>Active</label>
+                  <input
+                    type="checkbox"
+                    checked={pActive || pDefault}
+                    onChange={(e) => setPActive(e.target.checked)}
+                    disabled={pDefault}
+                    title={pDefault ? "Default prompt cannot be disabled" : ""}
+                  />
+                </div>
+                <div
+                  className="row"
+                  style={{
+                    gap: "0.5rem",
+                    alignItems: "center",
+                    marginTop: "0.25rem",
+                  }}
+                >
+                  <label style={{ minWidth: 120 }}>Default</label>
+                  <input
+                    type="checkbox"
+                    checked={pDefault}
+                    onChange={(e) => setPDefault(e.target.checked)}
+                  />
+                </div>
+                {/* Bottom status bar above the action bar (Persona tab only) */}
+                {message && (
+                  <div
+                    role="status"
+                    className="system-msg"
+                    style={{
+                      position: "fixed",
+                      left: 0,
+                      right: 0,
+                      bottom: "56px",
+                      background: "#0B1220",
+                      borderTop: "1px solid #1F2937",
+                      borderBottom: "1px solid #1F2937",
+                      padding: "0.5rem 1rem",
+                      color: "#F9FAFB",
+                      zIndex: 2,
+                    }}
+                  >
+                    {message}
+                  </div>
+                )}
+
+                {/* Fixed action bar at the bottom */}
+                <div
+                  style={{
+                    position: "fixed",
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    background: "#111827",
+                    borderTop: "1px solid #1F2937",
+                    padding: "0.75rem 1rem",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    gap: "0.5rem",
+                    zIndex: 2,
+                  }}
+                >
+                  <div style={{ display: "flex", gap: "0.5rem" }}>
+                    <button type="button" onClick={newPrompt}>
+                      New Prompt
+                    </button>
+                  </div>
+                  <div style={{ display: "flex", gap: "0.5rem" }}>
+                    <button
+                      type="button"
+                      onClick={savePrompt}
+                      disabled={pSaving}
+                    >
+                      {pSaving ? "Saving…" : "Save"}
+                    </button>
+                    {selectedPromptId != null && (
+                      <button type="button" onClick={deletePrompt}>
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
             </section>
           )}
 


### PR DESCRIPTION
- DB: add system_prompts table with constraints (default implies active) and indexes
- API: CRUD under /api/settings/prompts with CSRF and rules (single default, cannot disable default)
- UI: Persona Settings tab with Markdown textarea, preferred LLMs list, active/default toggles
- UX: fixed bottom toolbar and status bar; align tab styling; New Prompt moved to toolbar (left), Save/Delete right

Builds: backend and frontend verified